### PR TITLE
Respect database prefix in quiz module (2.2 edition)

### DIFF
--- a/classes/filters.class.php
+++ b/classes/filters.class.php
@@ -427,7 +427,7 @@ class block_ajax_marking_groupid extends block_ajax_marking_filter_base {
                 MAX(displaytable.groupid) AS groupid,
                 displaytable.cmid
            FROM ({$visibilitysubquery}) AS displaytable
-     INNER JOIN mdl_groups_members members
+     INNER JOIN {groups_members} members
              ON members.groupid = displaytable.groupid
        GROUP BY members.userid,
                 displaytable.cmid

--- a/modules/quiz/block_ajax_marking_quiz.class.php
+++ b/modules/quiz/block_ajax_marking_quiz.class.php
@@ -347,16 +347,16 @@ class block_ajax_marking_quiz extends block_ajax_marking_module_base {
                        quiz_attempts.id  AS quizattemptid,
                        question_attempts.questionid,
                        question_attempts.slot
-                FROM   mdl_quiz moduletable
-                       INNER JOIN mdl_quiz_attempts quiz_attempts
+                FROM   {quiz} moduletable
+                       INNER JOIN {quiz_attempts} quiz_attempts
                          ON moduletable.id = quiz_attempts.quiz
-                       INNER JOIN mdl_question_attempts question_attempts
+                       INNER JOIN {question_attempts} question_attempts
                          ON question_attempts.questionusageid = quiz_attempts.uniqueid
-                       INNER JOIN mdl_question_attempt_steps sub
+                       INNER JOIN {question_attempt_steps} sub
                          ON question_attempts.id = sub.questionattemptid
-                       INNER JOIN mdl_question question
+                       INNER JOIN {question} question
                          ON question_attempts.questionid = question.id
-                       INNER JOIN mdl_course_modules course_modules
+                       INNER JOIN {course_modules} course_modules
                          ON course_modules.instance = moduletable.id
                             AND course_modules.module = :quizmoduleid
                 WHERE  quiz_attempts.timefinish > 0
@@ -364,7 +364,7 @@ class block_ajax_marking_quiz extends block_ajax_marking_module_base {
                        AND question_attempts.behaviour = 'manualgraded'
                        AND sub.state = 'needsgrading'
                        AND NOT EXISTS(SELECT 1
-                                      FROM   mdl_question_attempt_steps st
+                                      FROM   {question_attempt_steps} st
                                       WHERE  st.state IN ( 'gradedwrong', 'gradedpartial',
                                                            'gradedright',
                                                            'mangrwrong',


### PR DESCRIPTION
Hi again,

This is the same patch as #2, backported to 2.2. It touches one additional file which no longer exists in the 2.3 version.
