### PR TITLE
Add applicable_formats() to block_ajax_marking

### DIFF
--- a/block_ajax_marking.php
+++ b/block_ajax_marking.php
@@ -59,6 +59,21 @@ class block_ajax_marking extends block_base {
     }
 
     /**
+     * Standard function to determine where block can be placed
+     *
+     * @return array
+     */
+    public function applicable_formats() {
+        return array(
+            'site-index' => false,
+            'course-view' => true, 
+            'course-view-social' => false,
+            'mod' => true, 
+            'my' => false
+        );
+    }
+
+    /**
      * Standard get content function returns $this->content containing the block HTML etc
      *
      * @return bool|\stdClass


### PR DESCRIPTION
- to prevent addition of block where it's inappropriate, especially
  in My Moodle, as this would require implementation of an additional
  capability (myaddinstance).
  Without this change, core tests fail as they detect missing required capability.
